### PR TITLE
Using the local javaws jar.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
             <artifactId>jnlp-api</artifactId>
             <version>7.0</version>
             <scope>system</scope>
-            <systemPath>${java.home}/lib/javaws.jar</systemPath>
+            <systemPath>${project.basedir}/libs/jnlp-api.jar</systemPath>
         </dependency>
         <dependency>
             <groupId>org.python</groupId>


### PR DESCRIPTION
As discussed on [the initial patch](https://sourceforge.net/p/arianne/patches/646/), one can't build the project with OpenJDK because `javaws.jar` is not included:
```
[ERROR] Failed to execute goal on project Marauroa: Could not resolve dependencies for project net.sourceforge.javydreamercsw:Marauroa:jar:3.9.5-SNAPSHOT: Could not find artifact javax.jnlp:jnlp-api:jar:7.0 at specified path /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/javaws.jar -> [Help 1]
```
At the same time, the jar is already in `libs/`, so why not take it from there?
I am aware that this approach triggers a warning, but I know no other way.